### PR TITLE
Refactor CLI option handling

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """
 LLMarkable - Document Conversion Tool.
 
@@ -6,6 +5,7 @@ Transform source files (PDF, HTML, etc.) into remarkable, LLM-friendly Markdown 
 """
 
 import re
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Annotated, Any
@@ -29,6 +29,20 @@ app = typer.Typer(
     add_completion=False,
 )
 console = Console()
+
+
+@dataclass
+class CLIOptions:
+    """Grouped CLI options for conversion."""
+
+    output_dir: Path | None = None
+    chunk_size: int | None = None
+    min_tokens: int | None = None
+    chunk_overlap: int | None = None
+    preserve_tables: bool = True
+    preserve_images: bool = False
+    verbose: bool = False
+    individual_chunks: bool = False
 
 
 def version_callback(value: bool) -> None:
@@ -133,36 +147,23 @@ def _validate_input_file(input_file: Path, *, verbose: bool = False) -> None:
         raise typer.Exit(1) from e
 
 
-def _create_config_from_args(
-    output_dir: Path | None,
-    chunk_size: int | None,
-    min_tokens: int | None,
-    chunk_overlap: int | None,
-    *,
-    preserve_tables: bool,
-    preserve_images: bool,
-    verbose: bool,
-    individual_chunks: bool,
-) -> Config:
-    """Create configuration from CLI arguments."""
+def _create_config_from_options(options: CLIOptions) -> Config:
+    """Create configuration from CLI options."""
     config = Config.default()
 
-    # Override configuration with CLI arguments
-    if output_dir:
-        config.output_dir = str(output_dir)
-    if chunk_size:
-        config.chunk_size = chunk_size
-    if min_tokens:
-        config.min_tokens = min_tokens
-    if chunk_overlap is not None:
-        config.chunk_overlap = chunk_overlap
-    config.preserve_tables = preserve_tables
-    config.preserve_images = preserve_images
-    config.verbose = verbose
-    config.log_level = "DEBUG" if verbose else "INFO"
-
-    # Add individual_chunks to config (we'll add this to Config class)
-    config.individual_chunks = individual_chunks
+    if options.output_dir:
+        config.output_dir = str(options.output_dir)
+    if options.chunk_size:
+        config.chunk_size = options.chunk_size
+    if options.min_tokens:
+        config.min_tokens = options.min_tokens
+    if options.chunk_overlap is not None:
+        config.chunk_overlap = options.chunk_overlap
+    config.preserve_tables = options.preserve_tables
+    config.preserve_images = options.preserve_images
+    config.verbose = options.verbose
+    config.log_level = "DEBUG" if options.verbose else "INFO"
+    config.individual_chunks = options.individual_chunks
 
     return config
 
@@ -264,7 +265,7 @@ def _process_document(input_file: Path, config: Config, output_path: Path) -> No
 
 
 @app.command()
-def convert(
+def convert(  # noqa: PLR0913
     input_file: Annotated[
         Path,
         typer.Argument(help="Input file to convert (PDF, HTML)"),
@@ -349,17 +350,19 @@ def convert(
     # Validate file format
     _validate_file_format(input_file)
 
-    # Create configuration from arguments
-    config = _create_config_from_args(
-        output_dir,
-        chunk_size,
-        min_tokens,
-        chunk_overlap,
+    # Group CLI options and create configuration
+    options = CLIOptions(
+        output_dir=output_dir,
+        chunk_size=chunk_size,
+        min_tokens=min_tokens,
+        chunk_overlap=chunk_overlap,
         preserve_tables=preserve_tables,
         preserve_images=preserve_images,
         verbose=verbose,
         individual_chunks=individual_chunks,
     )
+
+    config = _create_config_from_options(options)
 
     # Validate configuration and create output directory
     output_path = _validate_and_create_output_dir(config)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Test suite for LLMarkable."""

--- a/tests/test_docx_pipeline_unit.py
+++ b/tests/test_docx_pipeline_unit.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """
 Unit tests for DOCX pipeline following pytest best practices.
 
@@ -133,7 +132,7 @@ class TestDocxPipelineProcessing:
                 Mock(text="chunk2"),
             ]
 
-            result = pipeline._chunk_document(mock_docling_document)
+            result = pipeline._chunk_document(mock_docling_document)  # noqa: SLF001
 
             assert isinstance(result, list)
             assert len(result) == 2

--- a/tests/test_html_pipeline_unit.py
+++ b/tests/test_html_pipeline_unit.py
@@ -232,7 +232,7 @@ class TestHTMLPipelineCreateChunks:
             test_file = tmp_path / "test.html"
             content = "First paragraph content that is long enough to pass the minimum length threshold.\n\nSecond paragraph that is also sufficiently long for processing."
 
-            chunks = pipeline._create_chunks(content, test_file)
+            chunks = pipeline._create_chunks(content, test_file)  # noqa: SLF001
 
             assert len(chunks) == 2
 
@@ -262,7 +262,7 @@ class TestHTMLPipelineCreateChunks:
             test_file = tmp_path / "test.html"
             content = "Short.\n\nThis is a longer paragraph that meets the minimum length requirement for processing.\n\nTiny."
 
-            chunks = pipeline._create_chunks(content, test_file)
+            chunks = pipeline._create_chunks(content, test_file)  # noqa: SLF001
 
             # Should only have the long paragraph
             assert len(chunks) == 1
@@ -283,7 +283,7 @@ class TestHTMLPipelineCreateChunks:
             test_file = tmp_path / "test.html"
             content = ""
 
-            chunks = pipeline._create_chunks(content, test_file)
+            chunks = pipeline._create_chunks(content, test_file)  # noqa: SLF001
 
             assert chunks == []
 
@@ -299,7 +299,7 @@ class TestHTMLPipelineCreateChunks:
             test_file = tmp_path / "test.html"
             content = "   \n  This paragraph has leading and trailing whitespace that should be removed.  \n   \n"
 
-            chunks = pipeline._create_chunks(content, test_file)
+            chunks = pipeline._create_chunks(content, test_file)  # noqa: SLF001
 
             assert len(chunks) == 1
             assert chunks[0]["content"] == "This paragraph has leading and trailing whitespace that should be removed."

--- a/tests/test_image_pipeline_unit.py
+++ b/tests/test_image_pipeline_unit.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """
 Unit tests for Image pipeline following pytest best practices.
 
@@ -132,7 +131,7 @@ class TestImagePipelineProcessing:
                 Mock(text="Additional text content"),
             ]
 
-            result = pipeline._chunk_document(mock_docling_document)
+            result = pipeline._chunk_document(mock_docling_document)  # noqa: SLF001
 
             assert isinstance(result, list)
             assert len(result) == 2
@@ -157,7 +156,7 @@ class TestImagePipelineProcessing:
             mock_chunks = [Mock(text="chunk1"), Mock(text="chunk2")]
             mock_hierarchical_chunker.chunk.return_value = iter(mock_chunks)
 
-            result = pipeline._chunk_document(mock_docling_document)
+            result = pipeline._chunk_document(mock_docling_document)  # noqa: SLF001
 
             assert result == mock_chunks
             mock_hierarchical_chunker.chunk.assert_called_once_with(

--- a/tests/test_pdf_pipeline_unit.py
+++ b/tests/test_pdf_pipeline_unit.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """
 Unit tests for PDF pipeline following pytest best practices.
 
@@ -167,7 +166,7 @@ class TestPDFPipelineProcessing:
                 Mock(text="chunk2"),
             ]
 
-            result = pipeline._chunk_document(mock_docling_document)
+            result = pipeline._chunk_document(mock_docling_document)  # noqa: SLF001
 
             assert isinstance(result, list)
             assert len(result) == 2

--- a/tests/test_pipeline_factory_integration.py
+++ b/tests/test_pipeline_factory_integration.py
@@ -19,15 +19,17 @@ class TestPipelineFactoryIntegration:
         """Test HTML pipeline creation and basic functionality."""
         html_file = Path("test.html")
 
-        with patch("pathlib.Path.exists", return_value=True):
-            with patch("src.pipelines.html.HTMLPipeline.process") as mock_process:
-                mock_process.return_value = [{"content": "test chunk"}]
+        with (
+            patch("pathlib.Path.exists", return_value=True),
+            patch("src.pipelines.html.HTMLPipeline.process") as mock_process,
+        ):
+            mock_process.return_value = [{"content": "test chunk"}]
 
-                pipeline = create_pipeline(html_file, test_config)
-                result = pipeline.process(html_file)
+            pipeline = create_pipeline(html_file, test_config)
+            result = pipeline.process(html_file)
 
-                assert len(result) == 1
-                assert result[0]["content"] == "test chunk"
+            assert len(result) == 1
+            assert result[0]["content"] == "test chunk"
 
     def test_should_create_pdf_pipeline_when_pdf_file_provided(
         self,
@@ -36,15 +38,17 @@ class TestPipelineFactoryIntegration:
         """Test PDF pipeline creation and basic functionality."""
         pdf_file = Path("test.pdf")
 
-        with patch("pathlib.Path.exists", return_value=True):
-            with patch("src.pipelines.pdf.PDFPipeline.process") as mock_process:
-                mock_process.return_value = [{"content": "pdf chunk"}]
+        with (
+            patch("pathlib.Path.exists", return_value=True),
+            patch("src.pipelines.pdf.PDFPipeline.process") as mock_process,
+        ):
+            mock_process.return_value = [{"content": "pdf chunk"}]
 
-                pipeline = create_pipeline(pdf_file, test_config)
-                result = pipeline.process(pdf_file)
+            pipeline = create_pipeline(pdf_file, test_config)
+            result = pipeline.process(pdf_file)
 
-                assert len(result) == 1
-                assert result[0]["content"] == "pdf chunk"
+            assert len(result) == 1
+            assert result[0]["content"] == "pdf chunk"
 
     def test_should_raise_file_not_found_when_file_missing(
         self,
@@ -61,15 +65,17 @@ class TestPipelineFactoryIntegration:
         """Test DOCX pipeline creation and basic functionality."""
         docx_file = Path("test.docx")
 
-        with patch("pathlib.Path.exists", return_value=True):
-            with patch("src.pipelines.docx.DocxPipeline.process") as mock_process:
-                mock_process.return_value = [{"content": "docx chunk"}]
+        with (
+            patch("pathlib.Path.exists", return_value=True),
+            patch("src.pipelines.docx.DocxPipeline.process") as mock_process,
+        ):
+            mock_process.return_value = [{"content": "docx chunk"}]
 
-                pipeline = create_pipeline(docx_file, test_config)
-                result = pipeline.process(docx_file)
+            pipeline = create_pipeline(docx_file, test_config)
+            result = pipeline.process(docx_file)
 
-                assert len(result) == 1
-                assert result[0]["content"] == "docx chunk"
+            assert len(result) == 1
+            assert result[0]["content"] == "docx chunk"
 
     def test_should_create_pptx_pipeline_when_pptx_file_provided(
         self,
@@ -78,15 +84,17 @@ class TestPipelineFactoryIntegration:
         """Test PPTX pipeline creation and basic functionality."""
         pptx_file = Path("test.pptx")
 
-        with patch("pathlib.Path.exists", return_value=True):
-            with patch("src.pipelines.pptx.PPTXPipeline.process") as mock_process:
-                mock_process.return_value = [{"content": "pptx chunk"}]
+        with (
+            patch("pathlib.Path.exists", return_value=True),
+            patch("src.pipelines.pptx.PPTXPipeline.process") as mock_process,
+        ):
+            mock_process.return_value = [{"content": "pptx chunk"}]
 
-                pipeline = create_pipeline(pptx_file, test_config)
-                result = pipeline.process(pptx_file)
+            pipeline = create_pipeline(pptx_file, test_config)
+            result = pipeline.process(pptx_file)
 
-                assert len(result) == 1
-                assert result[0]["content"] == "pptx chunk"
+            assert len(result) == 1
+            assert result[0]["content"] == "pptx chunk"
 
     def test_should_raise_value_error_when_unsupported_format(
         self,
@@ -95,6 +103,8 @@ class TestPipelineFactoryIntegration:
         """Test error handling for unsupported file formats."""
         unsupported_file = Path("test.xyz")
 
-        with patch("pathlib.Path.exists", return_value=True):
-            with pytest.raises(ValueError, match="Unsupported file format"):
-                create_pipeline(unsupported_file, test_config)
+        with (
+            patch("pathlib.Path.exists", return_value=True),
+            pytest.raises(ValueError, match="Unsupported file format"),
+        ):
+            create_pipeline(unsupported_file, test_config)

--- a/tests/test_pptx_pipeline_unit.py
+++ b/tests/test_pptx_pipeline_unit.py
@@ -124,7 +124,7 @@ class TestPPTXPipelineProcessing:
                 Mock(text="Slide 2: Content"),
             ]
 
-            result = pipeline._chunk_document(mock_docling_document)
+            result = pipeline._chunk_document(mock_docling_document)  # noqa: SLF001
 
             assert isinstance(result, list)
             assert len(result) == 2


### PR DESCRIPTION
## Summary
- remove unnecessary shebangs
- group CLI arguments via `CLIOptions` dataclass
- ignore `PLR0913` for the CLI entrypoint
- fix test style issues and combine nested context managers
- add missing test package docstring

## Testing
- `ruff check`
- `pytest -q` *(fails: ModuleNotFoundError for `docling_core`)*

------
https://chatgpt.com/codex/tasks/task_e_6846d7d13cd88331a202470ebe94e93c