### PR TITLE
Configure mypy to ignore missing imports

### DIFF
--- a/main.py
+++ b/main.py
@@ -264,7 +264,7 @@ def _process_document(input_file: Path, config: Config, output_path: Path) -> No
         raise typer.Exit(1) from e
 
 
-@app.command()
+@app.command()  # type: ignore[misc]
 def convert(  # noqa: PLR0913
     input_file: Annotated[
         Path,
@@ -375,7 +375,7 @@ def convert(  # noqa: PLR0913
     _process_document(input_file, config, output_path)
 
 
-@app.command()
+@app.command()  # type: ignore[misc]
 def info() -> None:
     """Show information about supported formats and configuration."""
     console.print("🔧 [bold]LLMarkable - Document Converter[/bold]")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,5 +64,5 @@ strict = true
 # Allow some flexibility for complex third-party library interactions
 warn_return_any = false
 # Ignore missing imports for some third-party libraries that may not have complete type stubs
-ignore_missing_imports = false
+ignore_missing_imports = true
 

--- a/src/pipelines/pdf.py
+++ b/src/pipelines/pdf.py
@@ -112,7 +112,7 @@ class PDFPipeline(BasePipeline):
             if self.config.verbose:
                 self.console.print("  -> ✅ PDF converted successfully")
                 # Note: num_pages() may not have type annotations in docling_core yet
-                pages = docling_doc.num_pages()  # type: ignore[no-untyped-call]
+                pages = docling_doc.num_pages()
                 self.console.print(f"  -> Document pages: {pages}")
 
         except Exception as err:


### PR DESCRIPTION
## Summary
- enable mypy's `ignore_missing_imports`
- remove an unused ignore comment
- silence Typer decorator warnings

## Testing
- `ruff check .`
- `mypy .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'docling_core')*

------
https://chatgpt.com/codex/tasks/task_e_6846dc4700b48331b9911f763161522c