### PR TITLE
Remove redundant console and tokenizer assignments

### DIFF
--- a/src/pipelines/docx.py
+++ b/src/pipelines/docx.py
@@ -15,11 +15,9 @@ from docling_core.transforms.chunker.base import BaseChunk
 from docling_core.transforms.chunker.hierarchical_chunker import HierarchicalChunker
 from docling_core.transforms.chunker.hybrid_chunker import HybridChunker
 from docling_core.types.doc.document import DoclingDocument
-from rich.console import Console
-
 from src.config import Config
 from src.serializers import TableOptimizedSerializerProvider
-from src.utils import get_tokenizer, is_chunk_useful, merge_small_trailing_chunks
+from src.utils import is_chunk_useful, merge_small_trailing_chunks
 
 from .base import BasePipeline
 
@@ -30,10 +28,6 @@ class DocxPipeline(BasePipeline):
     def __init__(self, config: Config) -> None:
         """Initialize DOCX pipeline with Docling configuration."""
         super().__init__(config)
-        self.console = Console()
-
-        # Get tokenizer using the utils function
-        self.tokenizer = get_tokenizer(config)
 
         # Initialize chunkers with optimized configuration following Docling best practices
         # Use table-optimized serializer for DOCX documents which often contain structured content

--- a/src/pipelines/html.py
+++ b/src/pipelines/html.py
@@ -12,11 +12,9 @@ from docling_core.transforms.chunker.base import BaseChunk
 from docling_core.transforms.chunker.hierarchical_chunker import HierarchicalChunker
 from docling_core.transforms.chunker.hybrid_chunker import HybridChunker
 from docling_core.types.doc.document import DoclingDocument
-from rich.console import Console
-
 from src.config import Config
 from src.serializers import LLMarkableSerializerProvider
-from src.utils import get_tokenizer, is_chunk_useful, merge_small_trailing_chunks
+from src.utils import is_chunk_useful, merge_small_trailing_chunks
 
 from .base import BasePipeline
 
@@ -27,8 +25,6 @@ class HTMLPipeline(BasePipeline):
     def __init__(self, config: Config) -> None:
         """Initialize HTML pipeline with optimized Docling configuration."""
         super().__init__(config)
-        self.console = Console()
-        self.tokenizer = get_tokenizer(config)
 
         # Initialize chunkers with optimized configuration following Docling best practices
         serializer_provider = LLMarkableSerializerProvider(

--- a/src/pipelines/image.py
+++ b/src/pipelines/image.py
@@ -13,10 +13,8 @@ from docling_core.transforms.chunker.base import BaseChunk
 from docling_core.transforms.chunker.hierarchical_chunker import HierarchicalChunker
 from docling_core.transforms.chunker.hybrid_chunker import HybridChunker
 from docling_core.types.doc.document import DoclingDocument
-from rich.console import Console
-
 from src.config import Config
-from src.utils import get_tokenizer, is_chunk_useful, merge_small_trailing_chunks
+from src.utils import is_chunk_useful, merge_small_trailing_chunks
 
 from .base import BasePipeline
 
@@ -27,10 +25,6 @@ class ImagePipeline(BasePipeline):
     def __init__(self, config: Config) -> None:
         """Initialize Image pipeline with Docling OCR configuration."""
         super().__init__(config)
-        self.console = Console()
-
-        # Get tokenizer using the utils function
-        self.tokenizer = get_tokenizer(config)
 
         # Initialize chunkers with optimized configuration following Docling best practices
         from src.serializers import ImageOptimizedSerializerProvider

--- a/src/pipelines/pptx.py
+++ b/src/pipelines/pptx.py
@@ -13,10 +13,8 @@ from docling_core.transforms.chunker.base import BaseChunk
 from docling_core.transforms.chunker.hierarchical_chunker import HierarchicalChunker
 from docling_core.transforms.chunker.hybrid_chunker import HybridChunker
 from docling_core.types.doc.document import DoclingDocument
-from rich.console import Console
-
 from src.config import Config
-from src.utils import get_tokenizer, is_chunk_useful, merge_small_trailing_chunks
+from src.utils import is_chunk_useful, merge_small_trailing_chunks
 
 from .base import BasePipeline
 
@@ -27,10 +25,6 @@ class PPTXPipeline(BasePipeline):
     def __init__(self, config: Config) -> None:
         """Initialize PPTX pipeline with Docling configuration."""
         super().__init__(config)
-        self.console = Console()
-
-        # Get tokenizer using the utils function
-        self.tokenizer = get_tokenizer(config)
 
         # Initialize chunkers with optimized configuration following Docling best practices
         from src.serializers import LLMarkableSerializerProvider


### PR DESCRIPTION
## Summary
- rely on BasePipeline for console/tokenizer initialization
- clean imports in HTML, DOCX, PPTX, and Image pipelines

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'docling_core')*
- `pip install -e .` *(fails: Could not find a version that satisfies the requirement setuptools>=40.8.0)*

------
https://chatgpt.com/codex/tasks/task_e_6846fc7310a883319740706944d2824f