### PR TITLE
Update installation docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,11 @@ llmarkable/
 This project uses `uv` for package management and requires Python 3.12+.
 
 1.  Clone the repository.
-2.  Install the dependencies:
+2.  Install `uv`:
+    ```bash
+    curl -LsSf https://astral.sh/uv/install.sh | sh
+    ```
+3.  Install the dependencies:
     ```bash
     uv sync
     ```


### PR DESCRIPTION
## Summary
- mention how to install `uv` using the official install script

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'docling_core')*

------
https://chatgpt.com/codex/tasks/task_e_6847063e16788331b12ac81766540d53