### PR TITLE
Use extract_text_content in chunk processing

### DIFF
--- a/src/pipelines/base.py
+++ b/src/pipelines/base.py
@@ -16,7 +16,12 @@ from docling_core.types.doc.document import DoclingDocument
 from rich.console import Console
 
 from src.config import Config
-from src.utils import get_tokenizer, is_chunk_useful, merge_small_trailing_chunks
+from src.utils import (
+    extract_text_content,
+    get_tokenizer,
+    is_chunk_useful,
+    merge_small_trailing_chunks,
+)
 
 
 class BasePipeline(ABC):
@@ -144,7 +149,7 @@ class BasePipeline(ABC):
 
         for i, chunk in enumerate(chunks):
             # Extract text content
-            content = chunk.text
+            content = extract_text_content(chunk)
 
             # Apply content filtering with shared logic
             if not is_chunk_useful(content, self.config):

--- a/src/utils.py
+++ b/src/utils.py
@@ -109,17 +109,24 @@ def extract_text_content(chunk: object) -> str:
         String content of the chunk
 
     """
-    # Check for dictionary-like objects first
+    # Check for common object attributes first, ensuring actual string values
+    page_content = getattr(chunk, "page_content", None)
+    if isinstance(page_content, str):
+        return page_content
+
+    text = getattr(chunk, "text", None)
+    if isinstance(text, str):
+        return text
+
+    content_attr = getattr(chunk, "content", None)
+    if isinstance(content_attr, str):
+        return content_attr
+
+    # Then check for dictionary-like objects
     if hasattr(chunk, "get") and callable(chunk.get):
         content = chunk.get("content", "")
         return str(content)
-    # Then check for object attributes
-    if hasattr(chunk, "page_content"):
-        return str(chunk.page_content)
-    if hasattr(chunk, "text"):
-        return str(chunk.text)
-    if hasattr(chunk, "content"):
-        return str(chunk.content)
+
     return str(chunk)
 
 


### PR DESCRIPTION
## Summary
- use `extract_text_content` inside `_process_chunks_with_metadata`
- clean up text extraction helper to safely handle mocks

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684712a61010833180327ad89f2b7550