### PR TITLE
Add LLM provider scaffolding and refine flags

### DIFF
--- a/main.py
+++ b/main.py
@@ -49,6 +49,8 @@ class CLIOptions:
     use_granite_vision: bool = False
     pdf_backend: str | None = None
     artifacts_path: str | None = None
+    refine: bool = False
+    llm_provider: str | None = None
 
 
 def version_callback(value: bool) -> None:
@@ -176,6 +178,8 @@ def _create_config_from_options(options: CLIOptions) -> Config:
     config.use_granite_vision = options.use_granite_vision
     config.pdf_backend = options.pdf_backend
     config.artifacts_path = options.artifacts_path
+    config.refine = options.refine
+    config.llm_provider = options.llm_provider
 
     return config
 
@@ -365,6 +369,20 @@ def convert(  # noqa: PLR0913
             help="Use IBM Granite vision model for picture description (default: disabled)",
         ),
     ] = False,
+    refine: Annotated[
+        bool,
+        typer.Option(
+            "--refine/--no-refine",
+            help="Refine content with an LLM (Phase 2 placeholder)",
+        ),
+    ] = False,
+    llm_provider: Annotated[
+        str | None,
+        typer.Option(
+            "--llm-provider",
+            help="LLM provider to use for refinement (Phase 2 placeholder)",
+        ),
+    ] = None,
     pdf_backend: Annotated[
         str | None,
         typer.Option(
@@ -392,6 +410,9 @@ def convert(  # noqa: PLR0913
     """
     Convert a document to LLM-friendly Markdown format.
 
+    Phase 2 will add optional LLM-powered refinement controlled by the
+    ``--refine`` flag and provider selection.
+
     Examples:
         llmarkable document.pdf
         llmarkable document.html --output-dir results/ --chunk-size 1024
@@ -418,6 +439,8 @@ def convert(  # noqa: PLR0913
         enable_formula_enrichment=enable_formula_enrichment,
         enable_picture_description=enable_picture_description,
         use_granite_vision=use_granite_vision,
+        refine=refine,
+        llm_provider=llm_provider,
         pdf_backend=pdf_backend,
         artifacts_path=artifacts_path,
     )
@@ -468,6 +491,8 @@ def info() -> None:
     console.print(f"   Output Directory: {config.output_dir}")
     console.print(f"   Preserve Tables: {config.preserve_tables}")
     console.print(f"   Preserve Images: {config.preserve_images}")
+    console.print(f"   Refine: {config.refine}")
+    console.print(f"   LLM Provider: {config.llm_provider}")
 
 
 def _show_config_summary(input_file: Path, config: Config) -> None:
@@ -480,6 +505,8 @@ def _show_config_summary(input_file: Path, config: Config) -> None:
     console.print(f"   Chunk Overlap: {config.chunk_overlap} tokens")
     console.print(f"   Preserve Tables: {config.preserve_tables}")
     console.print(f"   Preserve Images: {config.preserve_images}")
+    console.print(f"   Refine: {config.refine}")
+    console.print(f"   LLM Provider: {config.llm_provider}")
     console.print()
 
 

--- a/src/config.py
+++ b/src/config.py
@@ -10,7 +10,11 @@ from pathlib import Path
 
 @dataclass
 class Config:
-    """Configuration settings for document conversion pipeline."""
+    """Configuration settings for document conversion pipeline.
+
+    Phase 2 will introduce optional LLM-powered refinement using these
+    configuration flags.
+    """
 
     # Validation constants
     MIN_MULTIPLIER: float = 0.1
@@ -116,6 +120,10 @@ class Config:
     # Pre-defined vision models (shortcuts)
     use_granite_vision: bool = False  # Use IBM Granite vision model
     use_smolvlm: bool = False  # Use SmolVLM model
+
+    # Phase 2 LLM refinement
+    refine: bool = False  # Enable content refinement (Phase 2 feature)
+    llm_provider: str | None = None  # Selected provider name for refinement
 
     @classmethod
     def default(cls) -> "Config":

--- a/src/llm/__init__.py
+++ b/src/llm/__init__.py
@@ -1,0 +1,5 @@
+"""Phase 2 LLM providers."""
+
+from .base import BaseLLMProvider, NoOpProvider
+
+__all__ = ["BaseLLMProvider", "NoOpProvider"]

--- a/src/llm/base.py
+++ b/src/llm/base.py
@@ -1,0 +1,21 @@
+"""LLM provider interfaces for future refinement capabilities."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+
+class BaseLLMProvider(ABC):
+    """Abstract base class for Phase 2 LLM providers."""
+
+    @abstractmethod
+    def refine(self, text: str) -> str:
+        """Refine text content using an LLM."""
+
+
+class NoOpProvider(BaseLLMProvider):
+    """Placeholder LLM provider that returns text unchanged."""
+
+    def refine(self, text: str) -> str:
+        """Return text without modification."""
+        return text

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -1,0 +1,16 @@
+"""Tests for CLI configuration parsing."""
+
+from main import CLIOptions, _create_config_from_options
+from src.config import Config
+
+
+class TestCLIConfigParsing:
+    """Ensure CLI options are stored in Config."""
+
+    def test_should_store_refine_options(self) -> None:
+        options = CLIOptions(refine=True, llm_provider="noop")
+        config = _create_config_from_options(options)
+
+        assert isinstance(config, Config)
+        assert config.refine is True
+        assert config.llm_provider == "noop"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -24,6 +24,8 @@ class TestConfigDefaults:
         assert config.preserve_tables is True
         assert config.verbose is False
         assert config.tokenizer_model == "BAAI/bge-small-en-v1.5"
+        assert config.refine is False
+        assert config.llm_provider is None
 
     def test_should_be_immutable_after_creation(self) -> None:
         """Test that config values can be modified after creation."""


### PR DESCRIPTION
## Summary
- add `llm` package with `BaseLLMProvider` and a simple `NoOpProvider`
- extend `Config` with optional `refine` and `llm_provider` fields
- update CLI to accept `--refine` and `--llm-provider` options
- include Phase 2 docstrings
- test that configuration defaults and CLI parsing work

## Testing
- `pytest -q`
- `mypy src`

------
https://chatgpt.com/codex/tasks/task_e_684714611ba08331b35d749445a5b7c5